### PR TITLE
Fix nonfunctional vroom tests and add related bootstrap.vim

### DIFF
--- a/bootstrap.vim
+++ b/bootstrap.vim
@@ -1,0 +1,57 @@
+" Copyright 2014 Google Inc. All rights reserved.
+"
+" Licensed under the Apache License, Version 2.0 (the "License");
+" you may not use this file except in compliance with the License.
+" You may obtain a copy of the License at
+"
+"     http://www.apache.org/licenses/LICENSE-2.0
+"
+" Unless required by applicable law or agreed to in writing, software
+" distributed under the License is distributed on an "AS IS" BASIS,
+" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+" See the License for the specific language governing permissions and
+" limitations under the License.
+
+" This file can be sourced to install the plugin and its dependencies if no
+" plugin manager is available.
+
+let s:plugin_path = expand('<sfile>:p:h')
+
+if !exists('*maktaba#compatibility#Disable')
+  try
+    " To check if Maktaba is loaded we must try calling a maktaba function.
+    " exists() is false for autoloadable functions that are not yet loaded.
+    call maktaba#compatibility#Disable()
+  catch /E117:/
+    " Maktaba is not installed. Check whether it's in a nearby directory.
+    let s:rtpsave = &runtimepath
+    " We'd like to use maktaba#path#Join, but maktaba doesn't exist yet.
+    let s:slash = exists('+shellslash') && !&shellslash ? '\' : '/'
+    let s:guess1 = fnamemodify(s:plugin_path, ':h') . s:slash . 'maktaba'
+    let s:guess2 = fnamemodify(s:plugin_path, ':h') . s:slash . 'vim-maktaba'
+    if isdirectory(s:guess1)
+      let &runtimepath .= ',' . s:guess1
+    elseif isdirectory(s:guess2)
+      let &runtimepath .= ',' . s:guess2
+    endif
+
+    try
+      " If we've just installed maktaba, we need to make sure that vi
+      " compatibility mode is off. Maktaba does not support vi compatibility.
+      call maktaba#compatibility#Disable()
+    catch /E117:/
+      " No luck.
+      let &runtimepath = s:rtpsave
+      unlet s:rtpsave
+      " We'd like to use maktaba#error#Shout, but maktaba doesn't exist yet.
+      echohl ErrorMsg
+      echomsg 'Maktaba not found, but coverage requires it. Please either:'
+      echomsg '1. Place maktaba in the same directory as this plugin.'
+      echomsg '2. Add maktaba to your runtimepath before using this plugin.'
+      echomsg 'Maktaba can be found at https://github.com/google/vim-maktaba.'
+      echohl NONE
+      finish
+    endtry
+  endtry
+endif
+call maktaba#plugin#GetOrInstall(s:plugin_path)

--- a/vroom/main.vroom
+++ b/vroom/main.vroom
@@ -1,11 +1,14 @@
-Install dependencies:
+This file demonstrates the basics of coverage usage.
+
+In order for these tests to work, maktaba MUST be in the same parent directory
+as coverage. Given that that's the case, all we have to do is source the
+setupvroom.vim file, which bootstraps the coverage plugin and configures it to
+work properly under vroom.
 
   :let g:repo = fnamemodify($VROOMFILE, ':p:h:h:h')
   :source $VROOMDIR/setupvroom.vim
   :let g:fixturepath = maktaba#path#Join([
   |fnamemodify($VROOMFILE, ':p:h'), 'fixture1', 'google3'])
-
-  :Glug! coverage
 
 The coverage plugin provides a :CoverageShow command that calls the coverage
 provider and renders the coverage, if available. Let's first create and register

--- a/vroom/setupvroom.vim
+++ b/vroom/setupvroom.vim
@@ -1,0 +1,30 @@
+" Copyright 2015 Google Inc. All rights reserved.
+"
+" Licensed under the Apache License, Version 2.0 (the "License");
+" you may not use this file except in compliance with the License.
+" You may obtain a copy of the License at
+"
+"     http://www.apache.org/licenses/LICENSE-2.0
+"
+" Unless required by applicable law or agreed to in writing, software
+" distributed under the License is distributed on an "AS IS" BASIS,
+" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+" See the License for the specific language governing permissions and
+" limitations under the License.
+
+" This file is used from vroom scripts to bootstrap the coverage plugin and
+" configure it to work properly under vroom.
+
+" Coverage does not support compatible mode.
+set nocompatible
+
+" Install the coverage plugin.
+let s:repo = expand('<sfile>:p:h:h')
+execute 'source' s:repo . '/bootstrap.vim'
+
+" Force plugin/ files to load since vroom installs the plugin after
+" |load-plugins| time.
+call maktaba#plugin#Get('coverage').Load()
+
+" Support vroom's fake shell executable and don't try to override it to sh.
+call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')


### PR DESCRIPTION
Existing vroom files reference a setupvroom.vim but that file apparently didn't get added to the repo. This adds missing files and gets the test passing.