### PR TITLE
use the documented CoverageData api

### DIFF
--- a/python/vim_coverage.py
+++ b/python/vim_coverage.py
@@ -33,6 +33,10 @@ def GetCoveragePyLines(path, source_file):
     cov.load()
   finally:
     os.chdir(prev_cwd)
-  covered_lines = cov.data.line_data()[source_file]
+  try:
+    # Coverage.py 4.0 and higher.
+    covered_lines = cov.data.lines(source_file)
+  except TypeError:
+    covered_lines = cov.data.line_data()[source_file]
   uncovered_lines = cov.analysis(source_file)[2]
   return (covered_lines, uncovered_lines)


### PR DESCRIPTION
Since [this commit](https://bitbucket.org/ned/coveragepy/commits/b1787fdf12d774066251c36dec2c42ec76e7a45c) (in [4.0b1](http://coverage.readthedocs.io/en/coverage-4.3.4/changes.html#version-4-0b1-2015-08-02)) the `line_data` method on `cov.data` doesn't exist anymore. The new `.lines()` should be used I believe.