### PR TITLE
Add covimerage provider for vim filetype

### DIFF
--- a/autoload/coverage/vim.vim
+++ b/autoload/coverage/vim.vim
@@ -1,0 +1,29 @@
+" Copyright 2017 Google Inc. All rights reserved.
+"
+" Licensed under the Apache License, Version 2.0 (the "License");
+" you may not use this file except in compliance with the License.
+" You may obtain a copy of the License at
+"
+"     http://www.apache.org/licenses/LICENSE-2.0
+"
+" Unless required by applicable law or agreed to in writing, software
+" distributed under the License is distributed on an "AS IS" BASIS,
+" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+" See the License for the specific language governing permissions and
+" limitations under the License.
+
+"{{{ [covimerage](https://github.com/Vimjas/covimerage) provider.
+"    (based on coverage.py)
+
+function! coverage#vim#GetCovimerageProvider() abort
+  let l:provider = extend(copy(coverage#python#GetCoveragePyProvider()), {
+      \ 'name': 'covimerage'})
+
+  function! l:provider.IsAvailable(unused_filename) abort
+    return &filetype is# 'vim'
+  endfunction
+
+  return l:provider
+endfunction
+
+"}}}

--- a/plugin/coverage.vim
+++ b/plugin/coverage.vim
@@ -16,3 +16,4 @@ let s:registry = s:plugin.GetExtensionRegistry()
 call s:registry.SetValidator('coverage#EnsureProvider')
 
 call s:registry.AddExtension(coverage#python#GetCoveragePyProvider())
+call s:registry.AddExtension(coverage#vim#GetCovimerageProvider())


### PR DESCRIPTION
https://github.com/Vimjas/covimerage allows to generate a Coverage.py
compatible output, and is therefore easy to add, based on the existing
coverage.py provider.