### PR TITLE
vim_coverage.py: handle covered_lines being None

### DIFF
--- a/python/vim_coverage.py
+++ b/python/vim_coverage.py
@@ -39,4 +39,4 @@ def GetCoveragePyLines(path, source_file):
   except TypeError:
     covered_lines = cov.data.line_data()[source_file]
   uncovered_lines = cov.analysis(source_file)[2]
-  return (covered_lines, uncovered_lines)
+  return (covered_lines or [], uncovered_lines)


### PR DESCRIPTION
For a file with no covered lines `covered_lines` is None.

This patch ensures that an empty list gets returned then.

Using Coverage.py, version 4.5.1 with C extension.