### PR TITLE
Add :CoverageShow! and :CoverageToggle! to reload ignoring cache

### DIFF
--- a/autoload/coverage.vim
+++ b/autoload/coverage.vim
@@ -123,7 +123,8 @@ function! s:CoverageShow(skip_cache, ...) abort
   endif
 
   if a:0 > 0
-    call coverage#ShowCoverage(maktaba#ensure#IsString(a:1))
+    let l:provider = maktaba#ensure#IsString(a:1)
+    call coverage#ShowCoverage(l:provider)
   else
     call coverage#ShowCoverage()
   endif

--- a/plugin/commands.vim
+++ b/plugin/commands.vim
@@ -19,13 +19,13 @@ endif
 
 ""
 " Show coverage report. If variable b:coverage_provider is set, the provider
-" from it will be used.
-command -nargs=* -complete=customlist,coverage#CompletionList CoverageShow
-    \ call coverage#Show(<f-args>)
+" from it will be used.  Add a bang (CoverageShow!) to ignore the cache.
+command -nargs=* -bang -complete=customlist,coverage#CompletionList CoverageShow
+    \ call coverage#Show(<bang>0, <f-args>)
 
 ""
-" Toggle coverage report.
-command -nargs=0 CoverageToggle call coverage#Toggle()
+" Toggle coverage report.  Add a bang (CoverageToggle!) to ignore the cache.
+command -nargs=0 -bang CoverageToggle call coverage#Toggle(<bang>0)
 
 ""
 " Show coverage report when the file changed, using vimdiff.

--- a/vroom/main.vroom
+++ b/vroom/main.vroom
@@ -1,7 +1,16 @@
 This file demonstrates the basics of coverage usage.
 
 In order for these tests to work, maktaba MUST be in the same parent directory
-as coverage. Given that that's the case, all we have to do is source the
+as coverage.
+
+First, we need to work around for nvim prompting users to press enter.
+(See https://github.com/google/vim-codefmt/pull/131)
+
+  :if has('nvim')<CR>
+  |  set cmdheight=30<CR>
+  |endif<CR>
+
+Given that that's the case, all we have to do is source the
 setupvroom.vim file, which bootstraps the coverage plugin and configures it to
 work properly under vroom.
 
@@ -21,8 +30,13 @@ a fake coverage provider.
   : return a:file =~# '.*dummy.py'
   :endfunction
 
+  :let g:next_covered = 13
+  :let g:covered = [1, 3, 5, 7, 9, 11]
+
   :function TestGetCoverage(file)
-  : return {'covered': [1, 3, 5, 7, 9, 11, 13],
+  : let g:covered = add(g:covered, g:next_covered)
+  : let g:next_covered += 2
+  : return {'covered': g:covered,
   |     'uncovered': [2, 4, 6, 8, 10, 12, 14],
   |     'partial': []}
   :endfunction
@@ -34,8 +48,51 @@ a fake coverage provider.
   |      'IsAvailable': function('TestIsAvailable')})
 
   :silent edit $VROOMDIR/testdata/dummy.py
+
+Let's start with a simple test that shows that CoverageShow works.
+
   :CoverageShow test_coverage_provider
   ~ Coverage is 50.00% (7/14 lines).
+  :echom execute('sign place file='.$VROOMDIR.'/testdata/dummy.py')
+  ~ .*line=12\s+id=12\s+name=sign_uncovered.* (regex)
+  :echom execute('sign place file='.$VROOMDIR.'/testdata/dummy.py')
+  ~ .*line=13\s+id=13\s+name=sign_covered.* (regex)
+
+If we call it again, the result should be the same (because of the cache).
+
+  :CoverageShow
+  :CoverageStats
+  ~ Coverage is 50.00% (7/14 lines).
+  :echom execute('sign place file='.$VROOMDIR.'/testdata/dummy.py')
+  ~ .*line=14\s+id=14\s+name=sign_uncovered\s+priority=10$ (regex)
+
+If we use a bang, the cache should be ignored, and the result should change
+(TestGetCoverage should be called again, which adds another covered line to the
+list).
+
+  :CoverageShow!
+  ~ Coverage is 53.33% (8/15 lines).
+  :echom execute('sign place file='.$VROOMDIR.'/testdata/dummy.py')
+  ~ .*line=15\s+id=15\s+name=sign_covered.* (regex)
+
+Users should also be able to toggle coverage, which should cache the coverage
+while it's hidden:
+  :CoverageToggle
+  :CoverageToggle
+  :CoverageStats
+  ~ Coverage is 53.33% (8/15 lines).
+  :echom execute('sign place file='.$VROOMDIR.'/testdata/dummy.py')
+  ~ .*line=15\s+id=15\s+name=sign_covered\s+priority=10$ (regex)
+
+However, toggled coverage should not be cached if a bang is used:
+  :CoverageToggle
+  :CoverageToggle!
+  ~ Coverage is 56.25% (9/16 lines).
+  :echom execute('sign place file='.$VROOMDIR.'/testdata/dummy.py')
+  ~ .*line=17\s+id=17\s+name=sign_covered.* (regex)
+
+Finally, let's make sure that calling unrecognized providers fails gracefully:
+
   :silent file foo.unrecognized
   :CoverageShow test_coverage_provider
   ~ Error rendering coverage: ERROR\(NotFound\): Provider (regex)

--- a/vroom/main.vroom
+++ b/vroom/main.vroom
@@ -47,30 +47,18 @@ a fake coverage provider.
   |      'GetCoverage': function('TestGetCoverage'),
   |      'IsAvailable': function('TestIsAvailable')})
 
-  :function CheckForSign(lnum, name)
-  : let matches = sign_getplaced($VROOMDIR.'/testdata/dummy.py',
-  |      {'lnum': a:lnum, 'name': a:name})
-  : echom empty(matches[0].signs) ? 'sign missing' : 'sign found'
-  :endfunction
-
   :silent edit $VROOMDIR/testdata/dummy.py
 
 Let's start with a simple test that shows that CoverageShow works.
 
   :CoverageShow test_coverage_provider
   ~ Coverage is 50.00% (7/14 lines).
-  :call CheckForSign(12, 'sign_uncovered')
-  ~ sign found
-  :call CheckForSign(13, 'sign_covered')
-  ~ sign found
 
 If we call it again, the result should be the same (because of the cache).
 
   :CoverageShow
   :CoverageStats
   ~ Coverage is 50.00% (7/14 lines).
-  :call CheckForSign(14, 'sign_covered')
-  ~ sign found
 
 If we use a bang, the cache should be ignored, and the result should change
 (TestGetCoverage should be called again, which adds another covered line to the
@@ -78,8 +66,6 @@ list).
 
   :CoverageShow!
   ~ Coverage is 53.33% (8/15 lines).
-  :call CheckForSign(15, 'sign_covered')
-  ~ sign found
 
 Users should also be able to toggle coverage, which should cache the coverage
 while it's hidden:
@@ -87,15 +73,11 @@ while it's hidden:
   :CoverageToggle
   :CoverageStats
   ~ Coverage is 53.33% (8/15 lines).
-  :call CheckForSign(17, 'sign_covered')
-  ~ sign missing
 
 However, toggled coverage should not be cached if a bang is used:
   :CoverageToggle
   :CoverageToggle!
   ~ Coverage is 56.25% (9/16 lines).
-  :call CheckForSign(17, 'sign_covered')
-  ~ sign found
 
 Finally, let's make sure that calling unrecognized providers fails gracefully:
 

--- a/vroom/main.vroom
+++ b/vroom/main.vroom
@@ -47,24 +47,31 @@ a fake coverage provider.
   |      'GetCoverage': function('TestGetCoverage'),
   |      'IsAvailable': function('TestIsAvailable')})
 
+  :function CheckForSign(lnum, name)
+  : let matches = sign_getplaced($VROOMDIR.'/testdata/dummy.py',
+  |      {'lnum': a:lnum, 'name': a:name})
+  : echom string(matches)
+  : echom empty(matches[0].signs) ? 'sign missing' : 'sign found'
+  :endfunction
+
   :silent edit $VROOMDIR/testdata/dummy.py
 
 Let's start with a simple test that shows that CoverageShow works.
 
   :CoverageShow test_coverage_provider
   ~ Coverage is 50.00% (7/14 lines).
-  :echom execute('sign place file='.$VROOMDIR.'/testdata/dummy.py')
-  ~ .*line=12\s+id=12\s+name=sign_uncovered.* (regex)
-  :echom execute('sign place file='.$VROOMDIR.'/testdata/dummy.py')
-  ~ .*line=13\s+id=13\s+name=sign_covered.* (regex)
+  :call CheckForSign(12, 'sign_uncovered')
+  ~ sign found
+  :call CheckForSign(13, 'sign_covered')
+  ~ sign found
 
 If we call it again, the result should be the same (because of the cache).
 
   :CoverageShow
   :CoverageStats
   ~ Coverage is 50.00% (7/14 lines).
-  :echom execute('sign place file='.$VROOMDIR.'/testdata/dummy.py')
-  ~ .*line=14\s+id=14\s+name=sign_uncovered\s+priority=10$ (regex)
+  :call CheckForSign(14, 'sign_covered')
+  ~ sign found
 
 If we use a bang, the cache should be ignored, and the result should change
 (TestGetCoverage should be called again, which adds another covered line to the
@@ -72,8 +79,8 @@ list).
 
   :CoverageShow!
   ~ Coverage is 53.33% (8/15 lines).
-  :echom execute('sign place file='.$VROOMDIR.'/testdata/dummy.py')
-  ~ .*line=15\s+id=15\s+name=sign_covered.* (regex)
+  :call CheckForSign(15, 'sign_covered')
+  ~ sign found
 
 Users should also be able to toggle coverage, which should cache the coverage
 while it's hidden:
@@ -81,15 +88,15 @@ while it's hidden:
   :CoverageToggle
   :CoverageStats
   ~ Coverage is 53.33% (8/15 lines).
-  :echom execute('sign place file='.$VROOMDIR.'/testdata/dummy.py')
-  ~ .*line=15\s+id=15\s+name=sign_covered\s+priority=10$ (regex)
+  :call CheckForSign(17, 'sign_covered')
+  ~ sign missing
 
 However, toggled coverage should not be cached if a bang is used:
   :CoverageToggle
   :CoverageToggle!
   ~ Coverage is 56.25% (9/16 lines).
-  :echom execute('sign place file='.$VROOMDIR.'/testdata/dummy.py')
-  ~ .*line=17\s+id=17\s+name=sign_covered.* (regex)
+  :call CheckForSign(17, 'sign_covered')
+  ~ sign found
 
 Finally, let's make sure that calling unrecognized providers fails gracefully:
 

--- a/vroom/main.vroom
+++ b/vroom/main.vroom
@@ -50,7 +50,6 @@ a fake coverage provider.
   :function CheckForSign(lnum, name)
   : let matches = sign_getplaced($VROOMDIR.'/testdata/dummy.py',
   |      {'lnum': a:lnum, 'name': a:name})
-  : echom string(matches)
   : echom empty(matches[0].signs) ? 'sign missing' : 'sign found'
   :endfunction
 

--- a/vroom/main.vroom
+++ b/vroom/main.vroom
@@ -1,16 +1,7 @@
 This file demonstrates the basics of coverage usage.
 
 In order for these tests to work, maktaba MUST be in the same parent directory
-as coverage.
-
-First, we need to work around for nvim prompting users to press enter.
-(See https://github.com/google/vim-codefmt/pull/131)
-
-  :if has('nvim')<CR>
-  |  set cmdheight=30<CR>
-  |endif<CR>
-
-Given that that's the case, all we have to do is source the
+as coverage. Given that that's the case, all we have to do is source the
 setupvroom.vim file, which bootstraps the coverage plugin and configures it to
 work properly under vroom.
 

--- a/vroom/setupvroom.vim
+++ b/vroom/setupvroom.vim
@@ -29,6 +29,10 @@ call maktaba#plugin#Get('coverage').Load()
 " Support vroom's fake shell executable and don't try to override it to sh.
 call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')
 
+" Set cmdheight to avoid "Hit ENTER to continue" without needing :silent
+" https://github.com/google/vroom/issues/83
+set cmdheight=10
+
 function WriteFakeCoveragePyFile(path, lines_by_file) abort
   let l:python_command = has('python3') ? 'python3' : 'python'
   execute l:python_command '<< EOF'


### PR DESCRIPTION
Per #27, supplying bang should allow reloading and ignoring the cache,
so that users don't need to reload vim-coverage to refresh coverage
results.

There was a bit of extra conversation there that seems to have died out, and this wasn't a big change, so I figure even if it gets blown away by a future redesign it's worth the time to use now.  Let me know if there's a different approach I should take here, instead.

I've also made the tests a bit more stringent to help make sure I'm not
introducing any regressions.

Thanks for taking a look!