### PR TITLE
Update tests to match the modern versions of the coverage lib.

### DIFF
--- a/vroom/setupvroom.vim
+++ b/vroom/setupvroom.vim
@@ -50,6 +50,5 @@ if hasattr(cov, 'add_lines'):
   cov.add_lines(line_data_dict)
 else:
   cov.add_line_data(line_data_dict)
-cov.write_file(os.path.join(path, '.coverage'))
 EOF
 endfunction

--- a/vroom/setupvroom.vim
+++ b/vroom/setupvroom.vim
@@ -50,5 +50,7 @@ if hasattr(cov, 'add_lines'):
   cov.add_lines(line_data_dict)
 else:
   cov.add_line_data(line_data_dict)
+if hasattr(cov, 'write_file'):
+  cov.write_file(os.path.join(path, '.coverage'))
 EOF
 endfunction


### PR DESCRIPTION
The library migrated from text files awhile ago, so now you don't need to manually save the file.

This happened in the early 5.x: https://github.com/nedbat/coveragepy/releases/tag/coverage-5.0a2