### PR TITLE
Fix gcov list unpacking for raw section containing colons

### DIFF
--- a/autoload/coverage/gcov/parsing.vim
+++ b/autoload/coverage/gcov/parsing.vim
@@ -35,7 +35,8 @@ let s:plugin = maktaba#plugin#Get('coverage')
 " geninfo's man page, or view the man page at:
 " http://ltp.sourceforge.net/coverage/lcov/geninfo.1.php
 function! s:TryParseLine(line) abort
-  let [l:prefix, l:raw_info] = split(a:line, ':', 1)
+  let [l:prefix; l:raw_info] = split(a:line, ':', 1)
+  let l:raw_info = join(l:raw_info, ':')
   let l:prefix = maktaba#string#Strip(l:prefix)
 
   if l:prefix ==? 'BA' || l:prefix ==? 'DA'


### PR DESCRIPTION
When parsing lcov output generated by `grcov`, a Rust code coverage
tool, the error `Less targets than List items` is thrown when parsing
`FN` lines for functions nested within modules as Rust uses `::` as
a separator in nested hierarchies of modules.

By unpacking the prefix and collecting all other elements into a
separate list that is then joined using the same separator the issue is
resolved.